### PR TITLE
Automate camera position for vtk_plot.plot

### DIFF
--- a/master_visu_scripts/stress_plots.py
+++ b/master_visu_scripts/stress_plots.py
@@ -70,10 +70,10 @@ field = 've_stress_xx'
 # Subplot lables include the timestep number in the top left corner.
 # Use plot_scalar_bar=False to not plot the color bar.
 for x in range(len(axs.flat)):
-    img = vp.plot(files[x],field=field,
-                         bounds=bounds,
-                         plot_scalar_bar=False)
-    axs.flat[x].imshow(img,aspect='equal',extent=[0,100,0,100])
+    vp.plot(files[x],field=field,
+            bounds=bounds,
+            ax=axs.flat[x],
+            plot_scalar_bar=False)
     axs.flat[x].annotate(labels[x]+' t'+str(x),xy=(0.1,0.9),xycoords='axes fraction')
     # Maybe set separate titles for each subplot
     #axs.flat[x].set_title(f'Name {x}')

--- a/master_visu_scripts/vtk_plot.py
+++ b/master_visu_scripts/vtk_plot.py
@@ -20,8 +20,9 @@ def plot(file,field,bounds,ax=None,contours=False,
     Parameters
     ----------
     file : VTU or PVTU file to plot
-    field : Field to use for color. The default is 'density'.
-    bounds : Bounds by which to clip the plot. The default is None.
+    field : Field to use for color.
+    bounds : Bounds by which to clip the plot.
+    ax: Matplotlib axes on which to plot results. The default is None.
     contours : Boolean for whether to add temperature contours. 
         The default is False.
     cfields : Names of compositional fields to use if field is 'comp_field.' 
@@ -31,7 +32,7 @@ def plot(file,field,bounds,ax=None,contours=False,
 
     Returns
     -------
-    ax: Matplotlib Axes with results plotted.
+    ax: Matplotlib axes with results plotted.
 
     """
     


### PR DESCRIPTION
I modified the "plot" function to automatically set the camera position based on the bounds input by the user (in km) and plot the prescribed model using imshow in matplotlib. The function now returns a Matplotlib axes object instead of an image.

Although it appears to work with my extension models, I am not sure about the calculation for the Z position of the camera (variable "zoom"), which is currently scaled by the magnitude of the X direction, the aspect ratio of the window, and a scalar of 1.875. I cannot yet figure out any reason why 1.875 should work, but with the models I've tried, the axes in imshow correctly map with the intended box.