### PR TITLE
Added VTK version to requirements file.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ six==1.16.0
 tornado==6.1
 tqdm==4.62.2
 transforms3d==0.3.1
-vtk
+vtk==9.0.3
 wheel==0.37.0
 win32-setctime==1.0.3
 zipp==3.5.0


### PR DESCRIPTION
Specified vtk version of 9.0.3 in requirements.txt. Tested installing packages from this file locally using pip. Successfully ran vtk_plot.py. 

As a side note, I was not able to install the packages from this file using conda (2 of the packages listed couldn't be found), even though I generated requirements.txt from within a conda environment. We may want to consider also including an environment.yml file for conda users (though it's also possible to just use pip within a conda environment and install things that way).